### PR TITLE
fix: removed '--resize' in scripts

### DIFF
--- a/extract_dataset.py
+++ b/extract_dataset.py
@@ -15,7 +15,6 @@ print('Initiating dataset builder...')
 arg_parser = argparse.ArgumentParser()
 arg_parser.add_argument('-a', '--annotations', required=True, help='Input path to your "annotations" directory (Download avaialable on: https://www.kaggle.com/andrewmvd/face-mask-detection')
 arg_parser.add_argument('-i', '--images', required=True, help='Input path to your "images" directory (Download avaialable on: https://www.kaggle.com/andrewmvd/face-mask-detection')
-arg_parser.add_argument('-s', '--size', required=True, help='Desired output image size')
 arg_parser.add_argument('-o', '--output', required=True, help='Output path to the serialized (pickled) dataset')
 args = vars(arg_parser.parse_args())
 
@@ -75,14 +74,13 @@ for i in tqdm(range(len(img_paths))):
             face = img[bounding_boxes[j][1]:bounding_boxes[j][3], bounding_boxes[j][0]:bounding_boxes[j][2]]
             faces.append(face)
             
-        
             j += 1
             
         break
 
 print('[STATUS] Task completed: Read images & extract faces')
         
-IMG_SIZE = args['size']
+IMG_SIZE = 64
 print('[INFO] Resizing faces according to the input size: {}x{}....'.format(IMG_SIZE, IMG_SIZE))
 
 encoded_labels = []

--- a/train_and_evaluate_model.py
+++ b/train_and_evaluate_model.py
@@ -15,7 +15,6 @@ print('Initiating model training and evaluation...')
 
 arg_parser = argparse.ArgumentParser()
 arg_parser.add_argument('-p', '--path', required=True, help='Path to the embedded dataset') 
-arg_parser.add_argument('-r', '--resize', required=True, help='Resize face to a certain size (must be the same size with the one you specified in extract_dataset.py)')
 arg_parser.add_argument('-s', '--split_value', required=True, help='Train/test data split value (decimal point, e.g. 0.8)')
 arg_parser.add_argument('-b', '--batch_size', required=True, help='Train/test batch size')
 arg_parser.add_argument('-e', '--epochs', required=True, help='Number of training epochs')
@@ -33,16 +32,16 @@ print('[INFO] Converting dataset into tensors...')
 features = loaded_data['features']
 labels = loaded_data['labels']
 
-print('[INFO] All images will be resized to {}x{}'.format(args['resize'], args['resize']))
+IMG_SIZE = 64
+print('[INFO] All images will be resized to {}x{}'.format(IMG_SIZE, IMG_SIZE))
 
-IMG_SIZE = int(args['resize'])
 split_val = float(args['split_value'])
 
 features = np.asarray(features)
 features = np.reshape(features, [len(features), 3, IMG_SIZE, IMG_SIZE])
 labels = np.asarray(labels)
 
-print('[INFO] Training/test split: {}%'.format(int(split_val*100)))
+print('[INFO] Training/test split: {}/{}'.format(int(split_val*100), int(100 - (split_val*100))))
 
 n_train = int(split_val * len(features))
 train_features = features[:n_train]


### PR DESCRIPTION
- Removed '--resize' from `train_and_evaluate_model.py` and '--size' from `extract_dataset.py` and replaced them by a static 64 integer instead
- Fixed train/test split info print out